### PR TITLE
CDS-4293 - Part-1 - Headless Chrome. Update cookbooks (Leicester)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,10 +35,9 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-# PhantomJS
-ENV PHANTOMJS_VERSION 2.1.1
-RUN curl --compressed -L --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-$PHANTOMJS_VERSION \
-  && chmod a+x /usr/local/bin/phantomjs
+# Install Chrome
+RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
 # Ruby
 ENV RUBY_VERSION 2.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd6
 RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
 # Ruby
-ENV RUBY_VERSION 2.5
+ENV RUBY_VERSION 2.3
 RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get update \
   && apt-get install -y ruby$RUBY_VERSION ruby$RUBY_VERSION-dev ruby-switch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,6 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
 RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
-# PhantomJS
-ENV PHANTOMJS_VERSION 2.1.1
-RUN curl --compressed -L --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-$PHANTOMJS_VERSION \
-  && chmod a+x /usr/local/bin/phantomjs
-
 # Ruby
 ENV RUBY_VERSION 2.3
 RUN apt-add-repository ppa:brightbox/ruby-ng \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,11 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
 RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
+# PhantomJS
+ENV PHANTOMJS_VERSION 2.1.1
+RUN curl --compressed -L --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-$PHANTOMJS_VERSION \
+  && chmod a+x /usr/local/bin/phantomjs
+
 # Ruby
 ENV RUBY_VERSION 2.3
 RUN apt-add-repository ppa:brightbox/ruby-ng \

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ The naming convention is as follows (alphabetically increasing city names):
 | mckessoncds/ci-docker-images:ithaca         | 2.3.7 |    2.7.7 |  1.16.3 | 8.11.3 |  1.9.4 | 1.6.11 |    6u45 |
 | mckessoncds/ci-docker-images:juneau         | 2.3.7 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
 | mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:leicester      |       |          |         |        |        |        |         |
+| mckessoncds/ci-docker-images:leicester      | 2.5.1 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
 | mckessoncds/ci-docker-images:minneapolis    |       |          |         |        |        |        |         |
 | mckessoncds/ci-docker-images:new-orleans    |       |          |         |        |        |        |         |
+| mckessoncds/ci-docker-images:orlando        |       |          |         |        |        |        |         |
 
 
 Docker for Mac
@@ -38,7 +39,7 @@ To Prepare a New Image
 
 - git co -b <name of next unused city - see above>
 - Edit this README.md.
-  - Document the new image resource versions above. 
+  - Document the new image resource versions above.
   - Add a new city name to the end of the alphabetical sequence above.
 - Make the version changes in the Dockerfile.
 - `git add .` / `git commit` / `git push --set-upstream origin <branch-name>`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The naming convention is as follows (alphabetically increasing city names):
 | mckessoncds/ci-docker-images:ithaca         | 2.3.7 |    2.7.7 |  1.16.3 | 8.11.3 |  1.9.4 | 1.6.11 |    6u45 |
 | mckessoncds/ci-docker-images:juneau         | 2.3.7 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
 | mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:leicester      | 2.5.1 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:leicester      | 2.3.8 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
 | mckessoncds/ci-docker-images:minneapolis    |       |          |         |        |        |        |         |
 | mckessoncds/ci-docker-images:new-orleans    |       |          |         |        |        |        |         |
 | mckessoncds/ci-docker-images:orlando        |       |          |         |        |        |        |         |


### PR DESCRIPTION
Create a new docker image that includes chromedriver.
Set the ruby version back to 2.3.