### PR TITLE
Portland -- NODE 10.14.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
   && dpkg -i chefdk_$CHEFDK_VERSION-1_amd64.deb \
   && rm chefdk_$CHEFDK_VERSION-1_amd64.deb
 
-ENV NODE_VERSION 10.13.0
+ENV NODE_VERSION 10.14.0
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x| bash - \
   && apt-get install -y nodejs=$NODE_VERSION-1nodesource1

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The naming convention is as follows (alphabetically increasing city names):
 | mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
 | mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |    2.7.8 |  1.17.1 | 10.13.0| 1.12.3 | 1.6.11 |    6u45 |
 | mckessoncds/ci-docker-images:orlando        |       |          |         |        |        |        |         |
-| mckessoncds/ci-docker-images:portland       |       |          |         |        |        |        |         |
+| mckessoncds/ci-docker-images:portland       | 2.5.1 |    2.7.8 |  1.17.1 | 10.14.0| 1.12.3 | 1.6.11 |    6u45 |
 
 
 Docker for Mac


### PR DESCRIPTION
A [recent Node release containing security updates](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V10.md#2018-11-27-version-10140-dubnium-lts-rvagg) prompted this image.

This image will be used for cds-tools.