### PR TITLE
Add project column to README table indicating image used

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,28 +5,28 @@ These are public images to run CI (continuous integration) building and testing 
 
 The naming convention is as follows (alphabetically increasing city names):
 
-| Name:tag                                    | Ruby  | Rubygems | Bundler | Node    | Yarn   | ChefDK | JavaJDK |
-|---------------------------------------------|------:|---------:|--------:|--------:|------: |-------:|--------:|
-| mckessoncds/ci-docker-images:austin         | 2.3.6 |    2.7.5 |         |  8.10.0 |  1.5.1 |  1.6.1 |         |
-| mckessoncds/ci-docker-images:buffalo        | 2.3.7 |    2.7.5 |         |  8.11.1 |  1.5.1 |  1.6.1 |         |
-| mckessoncds/ci-docker-images:chicago        | 2.3.7 |    2.7.5 |         |  8.11.1 |  1.5.1 | 1.6.11 |         |
-| mckessoncds/ci-docker-images:durham         | 2.3.7 |    2.7.5 |         |  8.11.1 |  1.5.1 | 1.6.11 |    6u45 |
-| ~~mckessoncds/ci-docker-images:eugene~~     |       |          |         |         |        |        |         |
-| mckessoncds/ci-docker-images:fresno         | 2.3.7 |    2.7.7 |         |  8.11.2 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:fresno-ubuntu  | 2.3.7 |    2.7.7 |  1.16.2 |  8.11.2 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:garland        | 2.3.7 |    2.7.7 |         |  8.11.3 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:garland-ubuntu | 2.3.7 |    2.7.7 |  1.16.2 |  8.11.3 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:houston        | 2.5.1 |    2.7.7 |  1.16.2 |  8.11.3 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:ithaca         | 2.3.7 |    2.7.7 |  1.16.3 |  8.11.3 |  1.9.4 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:juneau         | 2.3.7 |    2.7.7 |  1.16.6 |  8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |    2.7.7 |  1.16.6 |  8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:leicester      | 2.3.8 |    2.7.7 |  1.16.6 |  8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |    2.7.7 |  1.16.6 |  8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |    2.7.8 |  1.17.1 | 10.13.0 | 1.12.3 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:orlando        | 2.3.8 |    2.7.8 |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:portland       | 2.5.1 |    2.7.8 |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:quebec         |       |          |         |         |        |        |         |
-| mckessoncds/ci-docker-images:rochester      |       |          |         |         |        |        |         |
+| Name:tag                                    | Ruby  | Rubygems | Bundler | Node    | Yarn   | ChefDK | JavaJDK | Project |
+|---------------------------------------------|------:|---------:|--------:|--------:|------: |-------:|--------:|--------:|
+| mckessoncds/ci-docker-images:austin         | 2.3.6 |    2.7.5 |         |  8.10.0 |  1.5.1 |  1.6.1 |         |         |
+| mckessoncds/ci-docker-images:buffalo        | 2.3.7 |    2.7.5 |         |  8.11.1 |  1.5.1 |  1.6.1 |         |         |
+| mckessoncds/ci-docker-images:chicago        | 2.3.7 |    2.7.5 |         |  8.11.1 |  1.5.1 | 1.6.11 |         |         |
+| mckessoncds/ci-docker-images:durham         | 2.3.7 |    2.7.5 |         |  8.11.1 |  1.5.1 | 1.6.11 |    6u45 |         |
+| ~~mckessoncds/ci-docker-images:eugene~~     |       |          |         |         |        |        |         |         |
+| mckessoncds/ci-docker-images:fresno         | 2.3.7 |    2.7.7 |         |  8.11.2 |  1.7.0 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:fresno-ubuntu  | 2.3.7 |    2.7.7 |  1.16.2 |  8.11.2 |  1.7.0 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:garland        | 2.3.7 |    2.7.7 |         |  8.11.3 |  1.7.0 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:garland-ubuntu | 2.3.7 |    2.7.7 |  1.16.2 |  8.11.3 |  1.7.0 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:houston        | 2.5.1 |    2.7.7 |  1.16.2 |  8.11.3 |  1.7.0 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:ithaca         | 2.3.7 |    2.7.7 |  1.16.3 |  8.11.3 |  1.9.4 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:juneau         | 2.3.7 |    2.7.7 |  1.16.6 |  8.12.0 | 1.10.1 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |    2.7.7 |  1.16.6 |  8.12.0 | 1.10.1 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:leicester      | 2.3.8 |    2.7.7 |  1.16.6 |  8.12.0 | 1.10.1 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |    2.7.7 |  1.16.6 |  8.12.0 | 1.10.1 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |    2.7.8 |  1.17.1 | 10.13.0 | 1.12.3 | 1.6.11 |    6u45 |         |
+| mckessoncds/ci-docker-images:orlando        | 2.3.8 |    2.7.8 |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |    6u45 |   CVP   |
+| mckessoncds/ci-docker-images:portland       | 2.5.1 |    2.7.8 |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |    6u45 |   CDS   |
+| mckessoncds/ci-docker-images:quebec         |       |          |         |         |        |        |         |         |
+| mckessoncds/ci-docker-images:rochester      |       |          |         |         |        |        |         |         |
 
 
 Docker for Mac


### PR DESCRIPTION
This README change makes it easier to answer the question, _"Which image does CVP/CDS use?"_

We can instead indicate which image each project uses outside the table, but the column could be used to indicate trails of other info such as the end date of the image's use, version #'s, etc.

FYI: You'll want to click the button that displays the rich diff.