### PR TITLE
CDS-4448 - (quebec) Create a new docker image with Chrome 72 and other updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd6
 RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
 ENV CHROMEDRIVER_VERSION 2.45
-RUN curl -O https://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip
-RUN unzip chromedriver_linux64.zip -d bin && rm chromedriver_linux64.zip
+RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
+RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
 
 # PhantomJS
 ENV PHANTOMJS_VERSION 2.1.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
 RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
-ENV CHROMEDRIVER_VERSION 2.45
+ENV CHROMEDRIVER_VERSION 2.46
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,10 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
 RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
+ENV CHROMEDRIVER_VERSION 2.45
+RUN curl -O https://chromedriver.storage.googleapis.com/2.46/chromedriver_linux64.zip
+RUN unzip chromedriver_linux64.zip -d bin && rm chromedriver_linux64.zip
+
 # PhantomJS
 ENV PHANTOMJS_VERSION 2.1.1
 RUN curl --compressed -L --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-$PHANTOMJS_VERSION \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN curl --compressed -L --output /usr/local/bin/phantomjs https://s3.amazonaws.
   && chmod a+x /usr/local/bin/phantomjs
 
 # Ruby
-ENV RUBY_VERSION 2.3
+ENV RUBY_VERSION 2.5
 RUN apt-add-repository ppa:brightbox/ruby-ng \
   && apt-get update \
   && apt-get install -y ruby$RUBY_VERSION ruby$RUBY_VERSION-dev ruby-switch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,13 +57,13 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
   && dpkg -i chefdk_$CHEFDK_VERSION-1_amd64.deb \
   && rm chefdk_$CHEFDK_VERSION-1_amd64.deb
 
-ENV NODE_VERSION 10.14.0
+ENV NODE_VERSION 10.15.1
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x| bash - \
   && apt-get install -y nodejs=$NODE_VERSION-1nodesource1
 
 # Yarn
-ENV YARN_VERSION 1.12.3
+ENV YARN_VERSION 1.13.0
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
@@ -77,5 +77,5 @@ RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-re
 RUN echo 'gem: --no-document' >> ~/.gemrc
 ENV RUBYGEMS_VERSION 2.7.8
 RUN gem update --system $RUBYGEMS_VERSION
-ENV BUNDLER_VERSION 1.17.1
+ENV BUNDLER_VERSION 1.17.3
 RUN gem install bundler -v $BUNDLER_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,13 +35,13 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-# Install Chrome
-RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
-
 ENV CHROMEDRIVER_VERSION 2.46
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
+
+# Install the latest stable Chrome
+RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
 # PhantomJS
 ENV PHANTOMJS_VERSION 2.1.1

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ To Prepare a New Image
   - Document the new image resource versions above.
   - Add a new city name to the end of the alphabetical sequence above.
 - Make the version changes in the Dockerfile.
-- `git add .` / `git commit` / `git push --set-upstream origin &lt;branch-name&gt;`
-- When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:&lt;image-name&gt; /bin/bash`
+- `git add .` / `git commit` / `git push --set-upstream origin \<branch-name\>`
+- When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:\<image-name\> /bin/bash`
   Note: This will download the image and open a shell.
 - When the image loads, confirm the resource versions.
 - `git tag <branch-name>`

--- a/README.md
+++ b/README.md
@@ -5,29 +5,30 @@ These are public images to run CI (continuous integration) building and testing 
 
 The naming convention is as follows (alphabetically increasing city names):
 
-| Name:tag                                    | Ruby  | Rubygems | Bundler |  Node   |  Yarn  | ChefDK | JavaJDK | Chrome       | chromedriver |
-|---------------------------------------------|------:|---------:|--------:|--------:|-------:|-------:|--------:|-------------:|-------------:|
-| mckessoncds/ci-docker-images:austin         | 2.3.6 |   2.7.5  |         | 8.10.0  |  1.5.1 |  1.6.1 |         |              |              |
-| mckessoncds/ci-docker-images:buffalo        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 |  1.6.1 |         |              |              |
-| mckessoncds/ci-docker-images:chicago        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |         |              |              |
-| mckessoncds/ci-docker-images:durham         | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |  6u45   |              |              |
-| ~~mckessoncds/ci-docker-images:eugene~~     |       |          |         |         |        |        |         |              |              |
-| mckessoncds/ci-docker-images:fresno         | 2.3.7 |   2.7.7  |         | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:fresno-ubuntu  | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:garland        | 2.3.7 |   2.7.7  |         | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:garland-ubuntu | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:houston        | 2.5.1 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:ithaca         | 2.3.7 |   2.7.7  |  1.16.3 | 8.11.3  |  1.9.4 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:juneau         | 2.3.7 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:leicester      | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |   2.7.8  |  1.17.1 | 10.13.0 | 1.12.3 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:orlando        |       |          |         |         |        |        |         |              |              |
-| mckessoncds/ci-docker-images:portland       | 2.5.1 |   2.7.8  |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |  6u45   |              |              |
-| mckessoncds/ci-docker-images:quebec         | 2.5.x |   2.7.8  |  1.17.3 | 10.15.1 | 1.13.0 | 1.6.11 |  6u45   | 72.0.3626.81 | 2.46.628411  |
-| mckessoncds/ci-docker-images:rochester      |       |          |         |         |        |        |         |              |              |
-| mckessoncds/ci-docker-images:seattle        |       |          |         |         |        |        |         |              |              |
+|                                             |       |          |         |         |        |        |         |        | chrome |
+| Name:tag                                    | Ruby  | Rubygems | Bundler |  Node   |  Yarn  | ChefDK | JavaJDK | Chrome | driver |
+|---------------------------------------------|------:|---------:|--------:|--------:|-------:|-------:|--------:|-------:|-------:|
+| mckessoncds/ci-docker-images:austin         | 2.3.6 |   2.7.5  |         | 8.10.0  |  1.5.1 |  1.6.1 |         |        |        |
+| mckessoncds/ci-docker-images:buffalo        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 |  1.6.1 |         |        |        |
+| mckessoncds/ci-docker-images:chicago        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |         |        |        |
+| mckessoncds/ci-docker-images:durham         | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |  6u45   |        |        |
+| ~~mckessoncds/ci-docker-images:eugene~~     |       |          |         |         |        |        |         |        |        |
+| mckessoncds/ci-docker-images:fresno         | 2.3.7 |   2.7.7  |         | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:fresno-ubuntu  | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:garland        | 2.3.7 |   2.7.7  |         | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:garland-ubuntu | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:houston        | 2.5.1 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:ithaca         | 2.3.7 |   2.7.7  |  1.16.3 | 8.11.3  |  1.9.4 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:juneau         | 2.3.7 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:leicester      | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |   2.7.8  |  1.17.1 | 10.13.0 | 1.12.3 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:orlando        |       |          |         |         |        |        |         |        |        |
+| mckessoncds/ci-docker-images:portland       | 2.5.1 |   2.7.8  |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |  6u45   |        |        |
+| mckessoncds/ci-docker-images:quebec         | 2.5.x |   2.7.8  |  1.17.3 | 10.15.1 | 1.13.0 | 1.6.11 |  6u45   |   72   |  2.46  |
+| mckessoncds/ci-docker-images:rochester      |       |          |         |         |        |        |         |        |        |
+| mckessoncds/ci-docker-images:seattle        |       |          |         |         |        |        |         |        |        |
 
 Docker for Mac
 --------------

--- a/README.md
+++ b/README.md
@@ -59,4 +59,3 @@ Java JDK
 The JDK download is here:
 
 http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html
-              |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To Prepare a New Image
 - When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:{{image-name}} /bin/bash`
   Note: This will download the image and open a shell.
 - When the image loads, confirm the resource versions.
-- `git tag <branch-name>`
+- `git tag {{branch-name}}`
 - `git push --tags` # This will trigger a build of the docker image for CircleCI to use.
 
 Java JDK

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ These are public images to run CI (continuous integration) building and testing 
 
 The naming convention is as follows (alphabetically increasing city names):
 
-|                                             |       |          |         |         |        |        |         |        | chrome |
 | Name:tag                                    | Ruby  | Rubygems | Bundler |  Node   |  Yarn  | ChefDK | JavaJDK | Chrome | driver |
 |---------------------------------------------|------:|---------:|--------:|--------:|-------:|-------:|--------:|-------:|-------:|
 | mckessoncds/ci-docker-images:austin         | 2.3.6 |   2.7.5  |         | 8.10.0  |  1.5.1 |  1.6.1 |         |        |        |

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ To Prepare a New Image
   - Document the new image resource versions above.
   - Add a new city name to the end of the alphabetical sequence above.
 - Make the version changes in the Dockerfile.
-- `git add .` / `git commit` / `git push --set-upstream origin \<branch-name\>`
-- When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:\<image-name\> /bin/bash`
+- `git add .` / `git commit` / `git push --set-upstream origin {{branch-name}}`
+- When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:{{image-name}} /bin/bash`
   Note: This will download the image and open a shell.
 - When the image loads, confirm the resource versions.
 - `git tag <branch-name>`

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To Prepare a New Image
   - Document the new image resource versions above.
   - Add a new city name to the end of the alphabetical sequence above.
 - Make the version changes in the Dockerfile.
-- `git add .` / `git commit` / `git push --set-upstream origin <branch-name>`
+- `git add .` / `git commit` / `git push --set-upstream origin \<branch-name\>`
 - When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:<image-name> /bin/bash`
   Note: This will download the image and open a shell.
 - When the image loads, confirm the resource versions.

--- a/README.md
+++ b/README.md
@@ -5,26 +5,29 @@ These are public images to run CI (continuous integration) building and testing 
 
 The naming convention is as follows (alphabetically increasing city names):
 
-| Name:tag                                    | Ruby  | Rubygems | Bundler | Node   | Yarn   | ChefDK | JavaJDK |
-|---------------------------------------------|------:|---------:|--------:|-------:|------: |-------:|--------:|
-| mckessoncds/ci-docker-images:austin         | 2.3.6 |    2.7.5 |         | 8.10.0 |  1.5.1 |  1.6.1 |         |
-| mckessoncds/ci-docker-images:buffalo        | 2.3.7 |    2.7.5 |         | 8.11.1 |  1.5.1 |  1.6.1 |         |
-| mckessoncds/ci-docker-images:chicago        | 2.3.7 |    2.7.5 |         | 8.11.1 |  1.5.1 | 1.6.11 |         |
-| mckessoncds/ci-docker-images:durham         | 2.3.7 |    2.7.5 |         | 8.11.1 |  1.5.1 | 1.6.11 |    6u45 |
-| ~~mckessoncds/ci-docker-images:eugene~~     |       |          |         |        |        |        |         |
-| mckessoncds/ci-docker-images:fresno         | 2.3.7 |    2.7.7 |         | 8.11.2 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:fresno-ubuntu  | 2.3.7 |    2.7.7 |  1.16.2 | 8.11.2 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:garland        | 2.3.7 |    2.7.7 |         | 8.11.3 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:garland-ubuntu | 2.3.7 |    2.7.7 |  1.16.2 | 8.11.3 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:houston        | 2.5.1 |    2.7.7 |  1.16.2 | 8.11.3 |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:ithaca         | 2.3.7 |    2.7.7 |  1.16.3 | 8.11.3 |  1.9.4 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:juneau         | 2.3.7 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:leicester      | 2.3.8 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |    2.7.7 |  1.16.6 | 8.12.0 | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |    2.7.8 |  1.17.1 | 10.13.0| 1.12.3 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:orlando        |       |          |         |        |        |        |         |
-| mckessoncds/ci-docker-images:portland       | 2.5.1 |    2.7.8 |  1.17.1 | 10.14.0| 1.12.3 | 1.6.11 |    6u45 |
+| Name:tag                                    | Ruby  | Rubygems | Bundler | Node    | Yarn   | ChefDK | JavaJDK |
+|---------------------------------------------|------:|---------:|--------:|--------:|-------:|-------:|--------:|
+| mckessoncds/ci-docker-images:austin         | 2.3.6 |    2.7.5 |         | 8.10.0  |  1.5.1 |  1.6.1 |         |
+| mckessoncds/ci-docker-images:buffalo        | 2.3.7 |    2.7.5 |         | 8.11.1  |  1.5.1 |  1.6.1 |         |
+| mckessoncds/ci-docker-images:chicago        | 2.3.7 |    2.7.5 |         | 8.11.1  |  1.5.1 | 1.6.11 |         |
+| mckessoncds/ci-docker-images:durham         | 2.3.7 |    2.7.5 |         | 8.11.1  |  1.5.1 | 1.6.11 |    6u45 |
+| ~~mckessoncds/ci-docker-images:eugene~~     |       |          |         |         |        |        |         |
+| mckessoncds/ci-docker-images:fresno         | 2.3.7 |    2.7.7 |         | 8.11.2  |  1.7.0 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:fresno-ubuntu  | 2.3.7 |    2.7.7 |  1.16.2 | 8.11.2  |  1.7.0 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:garland        | 2.3.7 |    2.7.7 |         | 8.11.3  |  1.7.0 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:garland-ubuntu | 2.3.7 |    2.7.7 |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:houston        | 2.5.1 |    2.7.7 |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:ithaca         | 2.3.7 |    2.7.7 |  1.16.3 | 8.11.3  |  1.9.4 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:juneau         | 2.3.7 |    2.7.7 |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |    2.7.7 |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:leicester      | 2.3.8 |    2.7.7 |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |    2.7.7 |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |    2.7.8 |  1.17.1 | 10.13.0 | 1.12.3 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:orlando        |       |          |         |         |        |        |         |
+| mckessoncds/ci-docker-images:portland       | 2.5.1 |    2.7.8 |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:quebec         | 2.5.x |    2.7.8 |  1.17.3 | 10.15.1 | 1.13.0 | 1.6.11 |    6u45 |
+| mckessoncds/ci-docker-images:rochester      |       |          |         |         |        |        |         |
+| mckessoncds/ci-docker-images:seattle        |       |          |         |         |        |        |         |
 
 
 Docker for Mac

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ To Prepare a New Image
   - Document the new image resource versions above.
   - Add a new city name to the end of the alphabetical sequence above.
 - Make the version changes in the Dockerfile.
-- `git add .` / `git commit` / `git push --set-upstream origin \<branch-name\>`
-- When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:<image-name> /bin/bash`
+- `git add .` / `git commit` / `git push --set-upstream origin &lt;branch-name&gt;`
+- When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:&lt;image-name&gt; /bin/bash`
   Note: This will download the image and open a shell.
 - When the image loads, confirm the resource versions.
 - `git tag <branch-name>`

--- a/README.md
+++ b/README.md
@@ -5,30 +5,29 @@ These are public images to run CI (continuous integration) building and testing 
 
 The naming convention is as follows (alphabetically increasing city names):
 
-| Name:tag                                    | Ruby  | Rubygems | Bundler | Node    | Yarn   | ChefDK | JavaJDK |
-|---------------------------------------------|------:|---------:|--------:|--------:|-------:|-------:|--------:|
-| mckessoncds/ci-docker-images:austin         | 2.3.6 |    2.7.5 |         | 8.10.0  |  1.5.1 |  1.6.1 |         |
-| mckessoncds/ci-docker-images:buffalo        | 2.3.7 |    2.7.5 |         | 8.11.1  |  1.5.1 |  1.6.1 |         |
-| mckessoncds/ci-docker-images:chicago        | 2.3.7 |    2.7.5 |         | 8.11.1  |  1.5.1 | 1.6.11 |         |
-| mckessoncds/ci-docker-images:durham         | 2.3.7 |    2.7.5 |         | 8.11.1  |  1.5.1 | 1.6.11 |    6u45 |
-| ~~mckessoncds/ci-docker-images:eugene~~     |       |          |         |         |        |        |         |
-| mckessoncds/ci-docker-images:fresno         | 2.3.7 |    2.7.7 |         | 8.11.2  |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:fresno-ubuntu  | 2.3.7 |    2.7.7 |  1.16.2 | 8.11.2  |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:garland        | 2.3.7 |    2.7.7 |         | 8.11.3  |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:garland-ubuntu | 2.3.7 |    2.7.7 |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:houston        | 2.5.1 |    2.7.7 |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:ithaca         | 2.3.7 |    2.7.7 |  1.16.3 | 8.11.3  |  1.9.4 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:juneau         | 2.3.7 |    2.7.7 |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |    2.7.7 |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:leicester      | 2.3.8 |    2.7.7 |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |    2.7.7 |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |    2.7.8 |  1.17.1 | 10.13.0 | 1.12.3 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:orlando        |       |          |         |         |        |        |         |
-| mckessoncds/ci-docker-images:portland       | 2.5.1 |    2.7.8 |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:quebec         | 2.5.x |    2.7.8 |  1.17.3 | 10.15.1 | 1.13.0 | 1.6.11 |    6u45 |
-| mckessoncds/ci-docker-images:rochester      |       |          |         |         |        |        |         |
-| mckessoncds/ci-docker-images:seattle        |       |          |         |         |        |        |         |
-
+| Name:tag                                    | Ruby  | Rubygems | Bundler |  Node   |  Yarn  | ChefDK | JavaJDK | Chrome       | chromedriver |
+|---------------------------------------------|------:|---------:|--------:|--------:|-------:|-------:|--------:|-------------:|-------------:|
+| mckessoncds/ci-docker-images:austin         | 2.3.6 |   2.7.5  |         | 8.10.0  |  1.5.1 |  1.6.1 |         |              |              |
+| mckessoncds/ci-docker-images:buffalo        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 |  1.6.1 |         |              |              |
+| mckessoncds/ci-docker-images:chicago        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |         |              |              |
+| mckessoncds/ci-docker-images:durham         | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |  6u45   |              |              |
+| ~~mckessoncds/ci-docker-images:eugene~~     |       |          |         |         |        |        |         |              |              |
+| mckessoncds/ci-docker-images:fresno         | 2.3.7 |   2.7.7  |         | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:fresno-ubuntu  | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:garland        | 2.3.7 |   2.7.7  |         | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:garland-ubuntu | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:houston        | 2.5.1 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:ithaca         | 2.3.7 |   2.7.7  |  1.16.3 | 8.11.3  |  1.9.4 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:juneau         | 2.3.7 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:leicester      | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |   2.7.8  |  1.17.1 | 10.13.0 | 1.12.3 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:orlando        |       |          |         |         |        |        |         |              |              |
+| mckessoncds/ci-docker-images:portland       | 2.5.1 |   2.7.8  |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |  6u45   |              |              |
+| mckessoncds/ci-docker-images:quebec         | 2.5.x |   2.7.8  |  1.17.3 | 10.15.1 | 1.13.0 | 1.6.11 |  6u45   | 72.0.3626.81 | 2.46.628411  |
+| mckessoncds/ci-docker-images:rochester      |       |          |         |         |        |        |         |              |              |
+| mckessoncds/ci-docker-images:seattle        |       |          |         |         |        |        |         |              |              |
 
 Docker for Mac
 --------------
@@ -59,3 +58,4 @@ Java JDK
 The JDK download is here:
 
 http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html
+              |

--- a/README.md
+++ b/README.md
@@ -5,29 +5,30 @@ These are public images to run CI (continuous integration) building and testing 
 
 The naming convention is as follows (alphabetically increasing city names):
 
-| Name:tag                                    | Ruby  | Rubygems | Bundler |  Node   |  Yarn  | ChefDK | JavaJDK | Chrome | driver |
-|---------------------------------------------|------:|---------:|--------:|--------:|-------:|-------:|--------:|-------:|-------:|
-| mckessoncds/ci-docker-images:austin         | 2.3.6 |   2.7.5  |         | 8.10.0  |  1.5.1 |  1.6.1 |         |        |        |
-| mckessoncds/ci-docker-images:buffalo        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 |  1.6.1 |         |        |        |
-| mckessoncds/ci-docker-images:chicago        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |         |        |        |
-| mckessoncds/ci-docker-images:durham         | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |  6u45   |        |        |
-| ~~mckessoncds/ci-docker-images:eugene~~     |       |          |         |         |        |        |         |        |        |
-| mckessoncds/ci-docker-images:fresno         | 2.3.7 |   2.7.7  |         | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:fresno-ubuntu  | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:garland        | 2.3.7 |   2.7.7  |         | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:garland-ubuntu | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:houston        | 2.5.1 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:ithaca         | 2.3.7 |   2.7.7  |  1.16.3 | 8.11.3  |  1.9.4 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:juneau         | 2.3.7 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:kannapolis     | 2.5.1 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:leicester      | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:minneapolis    | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:new-orleans    | 2.5.1 |   2.7.8  |  1.17.1 | 10.13.0 | 1.12.3 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:orlando        |       |          |         |         |        |        |         |        |        |
-| mckessoncds/ci-docker-images:portland       | 2.5.1 |   2.7.8  |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |  6u45   |        |        |
-| mckessoncds/ci-docker-images:quebec         | 2.5.x |   2.7.8  |  1.17.3 | 10.15.1 | 1.13.0 | 1.6.11 |  6u45   |   72   |  2.46  |
-| mckessoncds/ci-docker-images:rochester      |       |          |         |         |        |        |         |        |        |
-| mckessoncds/ci-docker-images:seattle        |       |          |         |         |        |        |         |        |        |
+| Name:tag       | Ruby  | Rubygems | Bundler |  Node   |  Yarn  | ChefDK | JavaJDK | Chrome | chromedriver |
+|----------------|------:|---------:|--------:|--------:|-------:|-------:|--------:|-------:|-------------:|
+| austin         | 2.3.6 |   2.7.5  |         | 8.10.0  |  1.5.1 |  1.6.1 |         |        |              |
+| buffalo        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 |  1.6.1 |         |        |              |
+| chicago        | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |         |        |              |
+| durham         | 2.3.7 |   2.7.5  |         | 8.11.1  |  1.5.1 | 1.6.11 |  6u45   |        |              |
+| ~~eugene~~     |       |          |         |         |        |        |         |        |              |
+| fresno         | 2.3.7 |   2.7.7  |         | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |        |              |
+| fresno-ubuntu  | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.2  |  1.7.0 | 1.6.11 |  6u45   |        |              |
+| garland        | 2.3.7 |   2.7.7  |         | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |        |              |
+| garland-ubuntu | 2.3.7 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |        |              |
+| houston        | 2.5.1 |   2.7.7  |  1.16.2 | 8.11.3  |  1.7.0 | 1.6.11 |  6u45   |        |              |
+| ithaca         | 2.3.7 |   2.7.7  |  1.16.3 | 8.11.3  |  1.9.4 | 1.6.11 |  6u45   |        |              |
+| juneau         | 2.3.7 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |              |
+| kannapolis     | 2.5.1 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |              |
+| leicester      | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |              |
+| minneapolis    | 2.3.8 |   2.7.7  |  1.16.6 | 8.12.0  | 1.10.1 | 1.6.11 |  6u45   |        |              |
+| new-orleans    | 2.5.1 |   2.7.8  |  1.17.1 | 10.13.0 | 1.12.3 | 1.6.11 |  6u45   |        |              |
+| orlando        |       |          |         |         |        |        |         |        |              |
+| portland       | 2.5.1 |   2.7.8  |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |  6u45   |        |              |
+| quebec         | 2.5.x |   2.7.8  |  1.17.3 | 10.15.1 | 1.13.0 | 1.6.11 |  6u45   |   72   |    2.46      |
+| rochester      |       |          |         |         |        |        |         |        |              |
+| seattle        |       |          |         |         |        |        |         |        |              |
+
 
 Docker for Mac
 --------------


### PR DESCRIPTION
Add version control for installing chromedriver and update the README.
Updates for yarn, node, ruby and bundle.