### PR TITLE
Update Chrome and Chromedriver versions to 74

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-ENV CHROMEDRIVER_VERSION 73.0.3683.68
+ENV CHROMEDRIVER_VERSION 74.0.3729.6
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ The naming convention is as follows (alphabetically increasing city names):
 | portland       | 2.5.1 |   2.7.8  |  1.17.1 | 10.14.0 | 1.12.3 | 1.6.11 |  6u45   |        |              |
 | quebec         | 2.5.x |   2.7.8  |  1.17.3 | 10.15.1 | 1.13.0 | 1.6.11 |  6u45   |   72   |    2.46      |
 | rochester      | 2.5.x |   3.0.3  |   2.0.1 | 10.15.2 | 1.15.2 | 1.6.11 |  6u45   |   73   | 73.0.3683.68 |
-| seattle        |       |          |         |         |        |        |         |        |              |
-| tempe          |       |          |         |         |        |        |         |        |              |
+| 2019.05.02     | 2.5.x |   3.0.3  |   2.0.1 | 10.15.2 | 1.15.2 | 1.6.11 |  6u45   |   74   | 74.0.3729.6  |
 
 
 Docker for Mac
@@ -45,7 +44,6 @@ To Prepare a New Image
 - git co -b <name of next unused city - see above>
 - Edit this README.md.
   - Document the new image resource versions above.
-  - Add a new city name to the end of the alphabetical sequence above.
 - Make the version changes in the Dockerfile.
 - `git add .` / `git commit` / `git push --set-upstream origin {{branch-name}}`
 - When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:{{image-name}} /bin/bash`


### PR DESCRIPTION
[CDS-4750](https://clearvalueplus.atlassian.net/browse/CDS-4750)

#### But Why?

[Latest Chrome is v74](http://chromedriver.chromium.org/downloads). Ok, actually 75 is listed there, but you're going to have to trust me that 75 hasn't been rolled out to all users yet. Any way, some of us experienced local test failures [for CVP](https://github.com/Mckesson-cds/clear_value_plus/pull/2160) due to this update, which have been resolved. Wouldn't it have been nice if Circle caught this for us? Well, with this change, now it can! 🎉 

#### Testing

You can test the image with the following commands:
- `docker run -it mckessoncds/ci-docker-images:branch-CDS-4750-update-chromedriver /bin/bash`
- Type `chromedriver&` into that command prompt and confirm version shown matches `74.0.3729.6`
- Type `google-chrome --version` and ensure major version is 74.
- `exit` out of that docker container