### PR TITLE
CDS-5128 - New docker image - Update ruby for CVEs. Update yarn and node.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-ENV CHROMEDRIVER_VERSION 76.0.3809.68
+ENV CHROMEDRIVER_VERSION 77.0.3865.40
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
 
@@ -61,13 +61,13 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
   && dpkg -i chefdk_$CHEFDK_VERSION-1_amd64.deb \
   && rm chefdk_$CHEFDK_VERSION-1_amd64.deb
 
-ENV NODE_VERSION 10.16.1
+ENV NODE_VERSION 10.16.3
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x| bash - \
   && apt-get install -y nodejs=$NODE_VERSION-1nodesource1
 
 # Yarn
-ENV YARN_VERSION 1.17.3
+ENV YARN_VERSION 1.19.0
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
@@ -79,7 +79,7 @@ RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-re
 
 # Ruby gems & bundler
 RUN echo 'gem: --no-document' >> ~/.gemrc
-ENV RUBYGEMS_VERSION 3.0.3
+ENV RUBYGEMS_VERSION 3.0.6
 RUN gem update --system $RUBYGEMS_VERSION
 ENV BUNDLER_VERSION 2.0.2
 RUN gem install bundler -v $BUNDLER_VERSION

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Docker Images for CI
 
 These are public images to run CI (continuous integration) building and testing for an Ruby/Node application. The intention is create baseline images that CI will use to run and test our application. These images have the required language support (Ruby, Node), and required test tools (ChefDK, phantomjs, codeclimate).
 
-The naming convention is as follows (alphabetically increasing city names):
+Add a row to this list with the tag (Name) of the current date and record the resource version changes:
 
 | Name:tag       | Ruby  | Rubygems | Bundler |  Node   |  Yarn  | ChefDK | JavaJDK | Chrome | chromedriver  |
 |----------------|------:|---------:|--------:|--------:|-------:|-------:|--------:|-------:|--------------:|
@@ -29,7 +29,8 @@ The naming convention is as follows (alphabetically increasing city names):
 | rochester      | 2.5.x |   3.0.3  |   2.0.1 | 10.15.2 | 1.15.2 | 1.6.11 |  6u45   |   73   | 73.0.3683.68  |
 | 2019.05.02     | 2.5.x |   3.0.3  |   2.0.1 | 10.15.2 | 1.15.2 | 1.6.11 |  6u45   |   74   |  74.0.3729.6  |
 | 2019.06.11     | 2.6.x |   3.0.3  |   2.0.1 | 10.16.0 | 1.16.0 | 1.6.11 |  6u45   |   75   |  75.0.3770.8  |
-| 2019.08.05	 | 2.6.x |   3.0.3  |   2.0.2 | 10.16.1	| 1.17.3 | 1.6.11 |  6u45   |   76   |  76.0.3809.68 |
+| 2019.08.05     | 2.6.x |   3.0.3  |   2.0.2 | 10.16.1	| 1.17.3 | 1.6.11 |  6u45   |   76   |  76.0.3809.68 |
+| 2019.10.01     | 2.6.x |   3.0.6  |   2.0.2 | 10.16.3 | 1.19.0 | 1.6.11 |  6u45   |   77   |  77.0.3865.40 |
 
 
 Docker for Mac
@@ -43,7 +44,7 @@ https://store.docker.com/editions/community/docker-ce-desktop-mac
 To Prepare a New Image
 ----------------------
 
-- git co -b <name of next unused city - see above>
+- git co -b <current date, matching the tag in the new row above>
 - Edit this README.md.
   - Document the new image resource versions above.
 - Make the version changes in the Dockerfile.


### PR DESCRIPTION
Update ruby for CVEs. Update yarn and node.

This ruby release includes security fixes for:

CVE-2019-16255: A code injection vulnerability of Shell#[] and Shell#test
CVE-2019-16254: HTTP response splitting in WEBrick (Additional fix)
CVE-2019-15845: A NUL injection vulnerability of File.fnmatch and File.fnmatch?
CVE-2019-16201: Regular Expression Denial of Service vulnerability of WEBrick’s Digest access authentication