### PR TITLE
2019.12.30 - Update to node.js 12.14.0, bundle 2.1.2, yarn 1.21.1 and latest chrome/chromedriver 79

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-ENV CHROMEDRIVER_VERSION 78.0.3904.70
+ENV CHROMEDRIVER_VERSION 79.0.3945.36
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
 
@@ -61,13 +61,13 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
   && dpkg -i chefdk_$CHEFDK_VERSION-1_amd64.deb \
   && rm chefdk_$CHEFDK_VERSION-1_amd64.deb
 
-ENV NODE_VERSION 12.13.0
+ENV NODE_VERSION 12.14.0
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x| bash - \
   && apt-get install -y nodejs
 
 # Yarn
-ENV YARN_VERSION 1.19.1
+ENV YARN_VERSION 1.21.1
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
@@ -81,5 +81,5 @@ RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-re
 RUN echo 'gem: --no-document' >> ~/.gemrc
 ENV RUBYGEMS_VERSION 3.0.6
 RUN gem update --system $RUBYGEMS_VERSION
-ENV BUNDLER_VERSION 2.0.2
+ENV BUNDLER_VERSION 2.1.2
 RUN gem install bundler -v $BUNDLER_VERSION

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The naming convention is as follows (alphabetically increasing city names):
 | 2019.08.05     | 2.6.x |   3.0.3  |   2.0.2 | 10.16.1 | 1.17.3 | 1.6.11 |  6u45   | 76.0.3809.68  |
 | 2019.10.11     | 2.6.x |   3.0.6  |   2.0.2 | 10.16.3 | 1.19.1 | 1.6.11 |  6u45   | 77.0.3865.40  |
 | 2019.10.26     | 2.6.x |   3.0.6  |   2.0.2 | 12.13.0 | 1.19.1 | 1.6.11 |  6u45   | 78.0.3904.70  |
-
+| 2019.12.30     | 2.6.x |   3.0.6  |   2.1.2 | 12.14.0 | 1.21.1 | 1.6.11 |  6u45   | 79.0.3945.36  |
 
 Docker for Mac
 --------------
@@ -45,7 +45,7 @@ https://store.docker.com/editions/community/docker-ce-desktop-mac
 To Prepare a New Image
 ----------------------
 
-- git co -b <name of next unused city - see above>
+- git co -b <current date>
 - Edit this README.md.
   - Document the new image resource versions above.
 - Make the version changes in the Dockerfile.  NOTE: Check http://chromedriver.chromium.org/home to determine the current stable chromedriver version.  Also, the ruby version with be the latest patchlevel ruby-ng release for the specified major and minor version in the Dockerfile. E.g., https://launchpad.net/~brightbox/+archive/ubuntu/ruby-ng/+index?field.series_filter=xenial


### PR DESCRIPTION
Update to node.js 12.14.0, bundle 2.1.2, yarn 1.21.1 and latest chrome/chromedriver 79

This is necessitated by a high severity security problem in npm (provided by node.js).
https://nodejs.org/en/blog/vulnerability/december-2019-security-releases/
