### PR TITLE
2020.01.07 - node 10.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
 
 ENV NODE_VERSION 10.18.0
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x| bash - \
+RUN curl -sL https://deb.nodesource.com/setup_10.x| bash - \
   && apt-get install -y nodejs
 
 # Yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
   && dpkg -i chefdk_$CHEFDK_VERSION-1_amd64.deb \
   && rm chefdk_$CHEFDK_VERSION-1_amd64.deb
 
-ENV NODE_VERSION 12.14.0
+ENV NODE_VERSION 10.18.0
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x| bash - \
   && apt-get install -y nodejs

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ The naming convention is as follows (alphabetically increasing city names):
 | 2019.10.11     | 2.6.x |   3.0.6  |   2.0.2 | 10.16.3 | 1.19.1 | 1.6.11 |  6u45   | 77.0.3865.40  |
 | 2019.10.26     | 2.6.x |   3.0.6  |   2.0.2 | 12.13.0 | 1.19.1 | 1.6.11 |  6u45   | 78.0.3904.70  |
 | 2019.12.30     | 2.6.x |   3.0.6  |   2.1.2 | 12.14.0 | 1.21.1 | 1.6.11 |  6u45   | 79.0.3945.36  |
+| 2020.01.07     | 2.6.x |   3.0.6  |   2.1.2 | 10.18.0 | 1.21.1 | 1.6.11 |  6u45   | 79.0.3945.36  |
+
+NOTE:  Currently, CDS Tools requires an older node release series (10.x.x), so other products will use a different docker image with the current LTS 
+
 
 Docker for Mac
 --------------
@@ -55,6 +59,7 @@ To Prepare a New Image
 - When the image loads, confirm the resource versions.
 - `git tag {{branch-name}}`
 - `git push --tags` # This will trigger a build of the docker image for CircleCI to use.
+
 
 Java JDK
 --------


### PR DESCRIPTION
Create an image variant for CDS Tools, which does not currently support node LTS 12.x.x.
This image updates node to 10.18.0, which includes a backported patch to fix an npm CVE.