### PR TITLE
CDS-5811 - Create two new docker images with latest releases of node and rubygems, and updated chromedriver and chrome

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
   && rm chefdk_$CHEFDK_VERSION-1_amd64.deb
 
 # NOTE: Using old Node due to CDS Tools using very old Ember.js packages that are not Node v12.x.x compatible
-ENV NODE_VERSION 10.21.0
+ENV NODE_VERSION 12.18.0
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x| bash - \
   && apt-get install -y nodejs
@@ -80,7 +80,7 @@ RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-re
 
 # Ruby gems & bundler
 RUN echo 'gem: --no-document' >> ~/.gemrc
-ENV RUBYGEMS_VERSION 3.1.2
+ENV RUBYGEMS_VERSION 3.1.4
 RUN gem update --system $RUBYGEMS_VERSION
 ENV BUNDLER_VERSION 2.1.4
 RUN gem install bundler -v $BUNDLER_VERSION

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The naming convention is as follows (alphabetically increasing city names):
 | 2020.03.20     | 2.6.x |   3.1.2  |   2.1.4 | 10.19.0 | 1.22.4 | 1.6.11 |  6u45   | 80.0.3987.106 | cds-tools  |
 | 2020.03.21     | 2.6.x |   3.1.2  |   2.1.4 | 12.16.1 | 1.22.4 | 1.6.11 |  6u45   | 80.0.3987.106 | cvp, quill |
 | 2020.06.05     | 2.6.x |   3.1.2  |   2.1.4 | 10.21.0 | 1.22.4 | 1.6.11 |  6u45   | 83.0.4103.39  | cds-tools  |
-| 2020.06.05-2   | 2.6.x |   3.1.2  |   2.1.4 | 12.18.0 | 1.22.4 | 1.6.11 |  6u45   | 83.0.4103.39  | cvp, quill |
+| 2020.06.09     | 2.6.x |   3.1.4  |   2.1.4 | 12.18.0 | 1.22.4 | 1.6.11 |  6u45   | 83.0.4103.39  | cvp, quill |
 
 **NOTE:  Currently, CDS Tools requires an older node release series (10.x.x), so other products will use a different docker image with the current LTS**
 


### PR DESCRIPTION
Security Updates for Node