### PR TITLE
2021.01.27-1 and 2021.01.27-2 - Remediate node vulnerabilities - CVE-2020-1971, CVE-2020-8265, CVE-2020-8287

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
 
 ENV NODE_VERSION 10.23.2
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x| bash - \
+RUN curl -sL https://deb.nodesource.com/setup_10.x| bash - \
   && apt-get install -y nodejs
 
 # Yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-re
 
 # Ruby gems & bundler
 RUN echo 'gem: --no-document' >> ~/.gemrc
-ENV RUBYGEMS_VERSION 3.2.7
+ENV RUBYGEMS_VERSION 3.1.4
 RUN gem update --system $RUBYGEMS_VERSION
-ENV BUNDLER_VERSION 2.2.7
+ENV BUNDLER_VERSION 2.1.4
 RUN gem install bundler -v $BUNDLER_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
   && dpkg -i chefdk_$CHEFDK_VERSION-1_amd64.deb \
   && rm chefdk_$CHEFDK_VERSION-1_amd64.deb
 
-ENV NODE_VERSION 14.15.4
+ENV NODE_VERSION 10.23.2
 
 RUN curl -sL https://deb.nodesource.com/setup_14.x| bash - \
   && apt-get install -y nodejs

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-ENV CHROMEDRIVER_VERSION 84.0.4147.30
+ENV CHROMEDRIVER_VERSION 88.0.4324.96
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
 
@@ -61,14 +61,13 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
   && dpkg -i chefdk_$CHEFDK_VERSION-1_amd64.deb \
   && rm chefdk_$CHEFDK_VERSION-1_amd64.deb
 
-# NOTE: Using old Node due to CDS Tools using very old Ember.js packages that are not Node v12.x.x compatible
-ENV NODE_VERSION 12.18.3
+ENV NODE_VERSION 14.15.4
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x| bash - \
+RUN curl -sL https://deb.nodesource.com/setup_14.x| bash - \
   && apt-get install -y nodejs
 
 # Yarn
-ENV YARN_VERSION 1.22.4
+ENV YARN_VERSION 1.22.5
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
@@ -80,7 +79,7 @@ RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-re
 
 # Ruby gems & bundler
 RUN echo 'gem: --no-document' >> ~/.gemrc
-ENV RUBYGEMS_VERSION 3.1.4
+ENV RUBYGEMS_VERSION 3.2.7
 RUN gem update --system $RUBYGEMS_VERSION
-ENV BUNDLER_VERSION 2.1.4
+ENV BUNDLER_VERSION 2.2.7
 RUN gem install bundler -v $BUNDLER_VERSION

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The naming convention is as follows (alphabetically increasing city names):
 | 2020.06.09     | 2.6.x |   3.1.4  |   2.1.4 | 12.18.0 | 1.22.4 | 1.6.11 |  6u45   | 83.0.4103.39  | cvp, quill |
 | 2020.08.10-1   | 2.7.x |   3.1.4  |   2.1.4 | 10.22.0 | 1.22.4 | 1.6.11 |  6u45   | 84.0.4147.30  | cds-tools  |
 | 2020.08.10-2   | 2.7.x |   3.1.4  |   2.1.4 | 12.18.3 | 1.22.4 | 1.6.11 |  6u45   | 84.0.4147.30  | cvp, quill |
-| 2021.01.27-1   | 2.7.x |   3.2.7  |   2.2.7 | 14.15.4 | 1.22.5 | 1.6.11 |  6u45   | 88.0.4324.96  | cvp, quill |
-| 2021.01.27-2   | 2.7.x |   3.2.7  |   2.2.7 | 10.23.2 | 1.22.5 | 1.6.11 |  6u45   | 88.0.4324.96  | cds-tools  |
+| 2021.01.27-1   | 2.7.x |   3.1.4  |   2.1.4 | 14.15.4 | 1.22.5 | 1.6.11 |  6u45   | 88.0.4324.96  | cvp, quill |
+| 2021.01.27-2   | 2.7.x |   3.1.4  |   2.1.4 | 10.23.2 | 1.22.5 | 1.6.11 |  6u45   | 88.0.4324.96  | cds-tools  |
 
 **NOTE:  Currently, CDS Tools requires an older node release series (10.x.x), so other products will use a different docker image with the current LTS**
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The naming convention is as follows (alphabetically increasing city names):
 | 2020.06.09     | 2.6.x |   3.1.4  |   2.1.4 | 12.18.0 | 1.22.4 | 1.6.11 |  6u45   | 83.0.4103.39  | cvp, quill |
 | 2020.08.10-1   | 2.7.x |   3.1.4  |   2.1.4 | 10.22.0 | 1.22.4 | 1.6.11 |  6u45   | 84.0.4147.30  | cds-tools  |
 | 2020.08.10-2   | 2.7.x |   3.1.4  |   2.1.4 | 12.18.3 | 1.22.4 | 1.6.11 |  6u45   | 84.0.4147.30  | cvp, quill |
+| 2021.01.27-1   | 2.7.x |   3.2.7  |   2.2.7 | 14.15.4 | 1.22.5 | 1.6.11 |  6u45   | 88.0.4324.96  | cvp, quill |
+| 2021.01.27-2   | 2.7.x |   3.2.7  |   2.2.7 | 10.23.2 | 1.22.5 | 1.6.11 |  6u45   | 88.0.4324.96  | cds-tools  |
 
 **NOTE:  Currently, CDS Tools requires an older node release series (10.x.x), so other products will use a different docker image with the current LTS**
 
@@ -58,7 +60,7 @@ To Prepare a New Image
 - git co -b <current date>
 - Edit this README.md.
   - Document the new image resource versions above.
-- Make the version changes in the Dockerfile.  NOTE: Check http://chromedriver.chromium.org/home to determine the current stable chromedriver version.  Also, the ruby version with be the latest patchlevel ruby-ng release for the specified major and minor version in the Dockerfile. E.g., https://launchpad.net/~brightbox/+archive/ubuntu/ruby-ng/+index?field.series_filter=xenial
+- Make the version changes in the Dockerfile.  NOTE: Check http://chromedriver.chromium.org/home to determine the current stable chromedriver version.  Also, the ruby version will be the latest patchlevel ruby-ng release for the specified major and minor version in the Dockerfile. E.g., https://launchpad.net/~brightbox/+archive/ubuntu/ruby-ng/+index?field.series_filter=xenial
 - `git add .` / `git commit` / `git push --set-upstream origin {{branch-name}}`
 - When the new image has been built, run `docker run -it mckessoncds/ci-docker-images:{{image-name}} /bin/bash`
   Note: This will download the image and open a shell.


### PR DESCRIPTION
- **CVE-2020-1971**: OpenSSL - EDIPARTYNAME NULL pointer de-reference (High)
This is a vulnerability in OpenSSL which may be exploited through Node.js. You can read more about it in https://www.openssl.org/news/secadv/20201208.txt

- **CVE-2020-8265**: use-after-free in TLSWrap (High)
Affected Node.js versions are vulnerable to a use-after-free bug in its TLS implementation. When writing to a TLS enabled socket, node::StreamBase::Write calls node::TLSWrap::DoWrite with a freshly allocated WriteWrap object as first argument. If the DoWrite method does not return an error, this object is passed back to the caller as part of a StreamWriteResult structure. This may be exploited to corrupt memory leading to a Denial of Service or potentially other exploits.

- **CVE-2020-8287**: HTTP Request Smuggling in nodejs (Low)
Affected versions of Node.js allow two copies of a header field in a http request. For example, two Transfer-Encoding header fields. In this case Node.js identifies the first header field and ignores the second. This can lead to HTTP Request Smuggling (https://cwe.mitre.org/data/definitions/444.html).