### PR TITLE
CDS-6466 - Remediate node and sudo vulnerabilities - CVE-2020-1971, CVE-2020-8265, CVE-2020-8287, and (for sudo) CVE-2021-3156

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,9 +61,9 @@ RUN curl --compressed -L --output chefdk_$CHEFDK_VERSION-1_amd64.deb https://pac
   && dpkg -i chefdk_$CHEFDK_VERSION-1_amd64.deb \
   && rm chefdk_$CHEFDK_VERSION-1_amd64.deb
 
-ENV NODE_VERSION 14.15.4
+ENV NODE_VERSION 10.23.2
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x| bash - \
+RUN curl -sL https://deb.nodesource.com/setup_10.x| bash - \
   && apt-get install -y nodejs
 
 # Yarn

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ https://store.docker.com/editions/community/docker-ce-desktop-mac
 To Prepare a New Image
 ----------------------
 
-1. git co -b <current date>
+1. git co -b <jira ticket reference for target repo>
 2. Edit this README.md. Document the new image resource versions above.
 3. Make the version changes in the Dockerfile.  NOTE: Check http://chromedriver.chromium.org/home to determine the current stable chromedriver version.  Also, the ruby version will be the latest patchlevel ruby-ng release for the specified major and minor version in the Dockerfile. E.g., https://launchpad.net/~brightbox/+archive/ubuntu/ruby-ng/+index?field.series_filter=xenial
 4. `git add .` / `git commit` / `git push --set-upstream origin {{branch-name}}`


### PR DESCRIPTION
[CDS-6466](https://projects.mckessonspecialtyhealth.com/jira/browse/CDS-6466)

