### PR TITLE
Add link to Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Docker Images for CI
 ====================
 
-These are public images to run CI (continuous integration) building and testing for an Ruby/Node application. The intention is create baseline images that CI will use to run and test our application. These images have the required language support (Ruby, Node), and required test tools (ChefDK, phantomjs, codeclimate).
+These are [public images](https://hub.docker.com/r/mckessoncds/ci-docker-images) to run CI (continuous integration) building and testing for an Ruby/Node application. The intention is create baseline images that CI will use to run and test our application. These images have the required language support (Ruby, Node), and required test tools (ChefDK, phantomjs, codeclimate).
 
 The naming convention is as follows (alphabetically increasing city names):
 


### PR DESCRIPTION
Add link to our list of images on Docker Hub to make it more accessible
to find.