### PR TITLE
Create a docker file for cvp testing

### DIFF
--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -1,0 +1,84 @@
+FROM ubuntu:18.04
+LABEL maintainer="kevin.olbrich@mckesson.com"
+
+# Java
+ENV JAVA_HOME=/jdk1.6.0_45
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
+COPY ./src/jdk-6u45-linux-x64.bin ./jdk-6u45-linux-x64.bin
+RUN chmod a+x ./jdk-6u45-linux-x64.bin
+RUN ./jdk-6u45-linux-x64.bin
+RUN rm ./jdk-6u45-linux-x64.bin
+# Java test runner
+RUN apt-get update && apt-get install -y ant && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y \
+  apt-transport-https \
+  build-essential \
+  ca-certificates \
+  curl \
+  git \
+  jq \
+  software-properties-common \
+  unzip \
+  zip \
+  && rm -rf /var/lib/apt/lists/*
+
+# set timezone to America/New_York
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && dpkg-reconfigure -f noninteractive tzdata
+
+# Dockerize
+ENV DOCKERIZE_VERSION v0.6.1
+RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
+ENV CHROMEDRIVER_VERSION 88.0.4324.96
+RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
+RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
+
+# Install the latest stable Chrome
+RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
+
+# PhantomJS
+ENV PHANTOMJS_VERSION 2.1.1
+RUN curl --compressed -L --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-$PHANTOMJS_VERSION \
+  && chmod a+x /usr/local/bin/phantomjs
+
+# Ruby
+ENV RUBY_VERSION 2.6
+RUN echo 'deb https://apt.fullstaqruby.org ubuntu-18.04 main' > /etc/apt/sources.list.d/fullstaq-ruby.list
+RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/main/fullstaq-ruby.asc \
+  && apt-key add fullstaq-ruby.asc \
+  && apt-get update \
+  && apt-get install -y fullstaq-ruby-common fullstaq-ruby-$RUBY_VERSION \
+  && rm -rf /var/lib/apt/lists/* \
+  && echo 'gem: --no-document' >> ~/.gemrc
+ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
+
+ENV NODE_VERSION 14.15.4
+ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
+RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
+  && apt-get install -y ./$DEB_FILE \
+  && rm $DEB_FILE \
+  && rm -rf /var/lib/apt/lists/*
+
+# Yarn
+ENV YARN_VERSION 1.22.5
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+  && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+  && apt-get update \
+  && apt-get install yarn=$YARN_VERSION-1 \
+  && rm -rf /var/lib/apt/lists/*
+
+# CodeClimate
+RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter \
+  && chmod a+x /usr/local/bin/cc-test-reporter
+
+# Ruby gems & bundler
+ENV BUNDLER_VERSION 2.2.7
+RUN gem install bundler:$BUNDLER_VERSION

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -22,10 +22,12 @@ RUN apt-get update && apt-get install -y \
   curl \
   git \
   jq \
+  python-minimal \
   software-properties-common \
   unzip \
   zip \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && update-ca-certificates
 
 # set timezone to America/New_York
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && dpkg-reconfigure -f noninteractive tzdata
@@ -35,14 +37,6 @@ ENV DOCKERIZE_VERSION v0.6.1
 RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
-ENV CHROMEDRIVER_VERSION 88.0.4324.96
-RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
-RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
-
-# Install the latest stable Chrome
-RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
 # PhantomJS
 ENV PHANTOMJS_VERSION 2.1.1
@@ -60,25 +54,34 @@ RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-ser
   && echo 'gem: --no-document' >> ~/.gemrc
 ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
-ENV NODE_VERSION 14.15.4
+ENV NODE_VERSION 14.16.0
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
-RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
+RUN curl -skLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get install -y ./$DEB_FILE \
-  && rm $DEB_FILE \
-  && rm -rf /var/lib/apt/lists/*
+  && rm $DEB_FILE
 
 # Yarn
 ENV YARN_VERSION 1.22.5
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
   && apt-get install yarn=$YARN_VERSION-1 \
   && rm -rf /var/lib/apt/lists/*
 
+# Ruby gems & bundler
+ENV BUNDLER_VERSION 2.2.15
+RUN gem install bundler:$BUNDLER_VERSION
+
+ENV CHROMEDRIVER_VERSION 89.0.4389.23
+RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
+  && unzip chromedriver_linux64.zip -d /usr/local/bin \
+  && rm chromedriver_linux64.zip
+
+# Install the latest stable Chrome
+RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+  && dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install \
+  && rm google-chrome-stable_current_amd64.deb
+
 # CodeClimate
 RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter \
   && chmod a+x /usr/local/bin/cc-test-reporter
-
-# Ruby gems & bundler
-ENV BUNDLER_VERSION 2.2.7
-RUN gem install bundler:$BUNDLER_VERSION

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -78,9 +78,11 @@ RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/ch
   && rm chromedriver_linux64.zip
 
 # Install the latest stable Chrome
-RUN curl -O https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-  && dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install \
-  && rm google-chrome-stable_current_amd64.deb
+RUN curl -SO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+  && apt-get update \
+  && apt-get install -y ./google-chrome-stable_current_amd64.deb \
+  && rm google-chrome-stable_current_amd64.deb \
+  && apt-get clean
 
 # CodeClimate
 RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter \

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -6,31 +6,37 @@ ENV JAVA_HOME=/jdk1.6.0_45
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY ./src/jdk-6u45-linux-x64.bin ./jdk-6u45-linux-x64.bin
 RUN chmod a+x ./jdk-6u45-linux-x64.bin
-RUN ./jdk-6u45-linux-x64.bin
-RUN rm ./jdk-6u45-linux-x64.bin
+RUN ./jdk-6u45-linux-x64.bin \
+  && rm ./jdk-6u45-linux-x64.bin
 # Java test runner
-RUN apt-get update && apt-get install -y ant && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+  && apt-get install -y ant \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update \
+  && apt-get install -y \
   apt-transport-https \
   build-essential \
   ca-certificates \
   curl \
   git \
   jq \
-  python-minimal \
   software-properties-common \
   unzip \
   zip \
   && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean \
   && update-ca-certificates
 
 # set timezone to America/New_York
-RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && dpkg-reconfigure -f noninteractive tzdata
+RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime \
+  && dpkg-reconfigure -f noninteractive tzdata
 
 # Dockerize
 ENV DOCKERIZE_VERSION v0.6.1
@@ -51,22 +57,27 @@ RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-ser
   && apt-get update \
   && apt-get install -y fullstaq-ruby-common fullstaq-ruby-$RUBY_VERSION \
   && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean \
   && echo 'gem: --no-document' >> ~/.gemrc
 ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
 ENV NODE_VERSION 14.16.0
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
-RUN curl -skLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
+RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
+  && apt-get update \
   && apt-get install -y ./$DEB_FILE \
-  && rm $DEB_FILE
+  && rm $DEB_FILE \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 # Yarn
 ENV YARN_VERSION 1.22.5
 RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
-  && apt-get install yarn=$YARN_VERSION-1 \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y yarn=$YARN_VERSION-1 \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 # Ruby gems & bundler
 ENV BUNDLER_VERSION 2.2.15
@@ -82,6 +93,7 @@ RUN curl -SO https://dl.google.com/linux/direct/google-chrome-stable_current_amd
   && apt-get update \
   && apt-get install -y ./google-chrome-stable_current_amd64.deb \
   && rm google-chrome-stable_current_amd64.deb \
+  && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 
 # CodeClimate


### PR DESCRIPTION
Create a docker image for CVP testing that does not include the chefdk, but does include the java sdk dependency.

* bumps node version