### PR TITLE
CDS-6626 - Install ant 1.9.6 for CVP

### DIFF
--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -9,10 +9,11 @@ RUN chmod a+x ./jdk-6u45-linux-x64.bin
 RUN ./jdk-6u45-linux-x64.bin \
   && rm ./jdk-6u45-linux-x64.bin
 # Java test runner
-RUN apt-get update \
-  && apt-get install -y ant \
-  && rm -rf /var/lib/apt/lists/* \
-  && apt-get clean
+ENV ANT_HOME=/apache-ant-1.9.6
+ENV PATH="${ANT_HOME}/bin:${PATH}"
+COPY ./src/apache-ant-1.9.6-bin.zip .
+RUN unzip apache-ant-1.9.6-bin.zip
+  && rm ./apache-ant-1.9.6-bin.zip
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -8,12 +8,6 @@ COPY ./src/jdk-6u45-linux-x64.bin ./jdk-6u45-linux-x64.bin
 RUN chmod a+x ./jdk-6u45-linux-x64.bin
 RUN ./jdk-6u45-linux-x64.bin \
   && rm ./jdk-6u45-linux-x64.bin
-# Java test runner
-ENV ANT_HOME=/apache-ant-1.9.6
-ENV PATH="${ANT_HOME}/bin:${PATH}"
-COPY ./src/apache-ant-1.9.6-bin.zip .
-RUN unzip apache-ant-1.9.6-bin.zip
-  && rm ./apache-ant-1.9.6-bin.zip
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata \
@@ -37,6 +31,13 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean \
   && update-ca-certificates
+
+# Java test runner
+ENV ANT_HOME=/apache-ant-1.9.6
+ENV PATH="${ANT_HOME}/bin:${PATH}"
+COPY ./src/apache-ant-1.9.6-bin.zip .
+RUN unzip apache-ant-1.9.6-bin.zip \
+  && rm ./apache-ant-1.9.6-bin.zip
 
 # set timezone to America/New_York
 RUN ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime \


### PR DESCRIPTION
The Ubuntu 18.04 default version of ant is not compatible with our RefUI Java SDK tests.  Use ant 1.9.6 instead.