### PR TITLE
CDS-6022 - subtask - New Docker image for Quill

### DIFF
--- a/Dockerfile.quill
+++ b/Dockerfile.quill
@@ -46,7 +46,7 @@ RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-ser
   && echo 'gem: --no-document' >> ~/.gemrc
 ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
-ENV NODE_VERSION 14.16.0
+ENV NODE_VERSION 14.16.1
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
 RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get update \
@@ -65,10 +65,10 @@ RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && apt-get clean
 
 # Ruby gems & bundler
-ENV BUNDLER_VERSION 2.2.15
+ENV BUNDLER_VERSION 2.2.16
 RUN gem install bundler:$BUNDLER_VERSION
 
-ENV CHROMEDRIVER_VERSION 89.0.4389.23
+ENV CHROMEDRIVER_VERSION 90.0.4430.24
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
   && unzip chromedriver_linux64.zip -d /usr/local/bin \
   && rm chromedriver_linux64.zip


### PR DESCRIPTION
Use ruby 2.7.3 – remediates CVEs
Use node 14.16.1 – remediates CVEs
Update bundler to 2.2.16, which resolved a problem in our Gemfile.lock. 