### PR TITLE
CDS-6741 - Update bundler, node, ruby, chromedriver and node versions

### DIFF
--- a/Dockerfile.cds-tools
+++ b/Dockerfile.cds-tools
@@ -34,7 +34,7 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-ENV CHROMEDRIVER_VERSION 90.0.4430.24
+ENV CHROMEDRIVER_VERSION 91.0.4472.19
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
 RUN unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
 

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -66,7 +66,7 @@ RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-ser
   && echo 'gem: --no-document' >> ~/.gemrc
 ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
-ENV NODE_VERSION 14.16.1
+ENV NODE_VERSION 14.17.0
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
 RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get update \
@@ -85,10 +85,10 @@ RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && apt-get clean
 
 # Ruby gems & bundler
-ENV BUNDLER_VERSION 2.2.16
+ENV BUNDLER_VERSION 2.2.17
 RUN gem install bundler:$BUNDLER_VERSION
 
-ENV CHROMEDRIVER_VERSION 90.0.4430.24
+ENV CHROMEDRIVER_VERSION 91.0.4472.19
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
   && unzip chromedriver_linux64.zip -d /usr/local/bin \
   && rm chromedriver_linux64.zip

--- a/Dockerfile.quill
+++ b/Dockerfile.quill
@@ -46,7 +46,7 @@ RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-ser
   && echo 'gem: --no-document' >> ~/.gemrc
 ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
-ENV NODE_VERSION 14.16.1
+ENV NODE_VERSION 14.17.0
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
 RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get update \
@@ -65,10 +65,10 @@ RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && apt-get clean
 
 # Ruby gems & bundler
-ENV BUNDLER_VERSION 2.2.16
+ENV BUNDLER_VERSION 2.2.17
 RUN gem install bundler:$BUNDLER_VERSION
 
-ENV CHROMEDRIVER_VERSION 90.0.4430.24
+ENV CHROMEDRIVER_VERSION 91.0.4472.19
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
   && unzip chromedriver_linux64.zip -d /usr/local/bin \
   && rm chromedriver_linux64.zip

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ The naming convention is as follows (alphabetically increasing city names):
 
 | Name:tag          | Ruby  | Rubygems | Bundler |  Node   |  Yarn  | chromedriver  |
 |-------------------|------:|---------:|--------:|--------:|-------:|--------------:|
-| 2021.02.01-cvp    | 2.6.x |  3.1.4   |  2.2.7  | 14.15.4 | 1.22.5 | 88.0.4324.96  |
-| 2021.02.01-cds    | 2.6.x |  3.1.4   |  2.2.7  | 10.23.2 | 1.22.5 | 88.0.4324.96  |
-| 2021.02.01-quill  | 2.7.x |  3.1.4   |  2.2.7  | 14.15.4 | 1.22.5 | 88.0.4324.96  |
-| 2021.03.18-cds    | 2.6.x |  3.0.3   |  2.2.14 | 10.24.0 | 1.22.5 | 89.0.4389.23  |
+| 2021.06.03-cds    | 2.6.7 |  3.0.3.1 |  2.2.17 | 12.22.1 | 1.22.5 |  91.0.4472.19 |
+| 2021.06.03-cvp    | 2.6.7 |  3.0.3.1 |  2.2.17 | 14.17.0 | 1.22.5 |  91.0.4472.19 |
+| 2021.06.03-quill  | 2.7.3 |  3.1.6   |  2.2.17 | 14.17.0 | 1.22.5 |  91.0.4472.19 |
+
 
 2021.03.18-chefdk only provides chefdk 1.6.11, which has an old version of embedded ruby (2.3.5).
+2021.03.18-chefdk also includes rubygems 2.6.14 and bundler 1.16.0
 
 Note:  Going forward, our server instances will use the version of rubygems that is provided by FullStaq ruby.
 


### PR DESCRIPTION
Note:  This PR creates updated docker images for multiple projects. The updates to Fullstaq ruby just grab whatever the latest patch release available for the major/minor version combo. 
The motivation for this PR is to use the latest stable versions of Chrome and chromedriver for all our CircleCI testing. This is important because the new Chrome v91 stable release has very significant performance improvements in the Javascript engine.  Also, CDS Tools needed the ruby patch, 2.6.7.
This PR also includes cleanup in the README.md. It now shows all the correct versions for all the images. Fixed some typos.
