### PR TITLE
CDS 6990 - New CDS Tools Docker image - node 12.22.5 - ruby 2.7.4

### DIFF
--- a/Dockerfile.cds
+++ b/Dockerfile.cds
@@ -68,7 +68,7 @@ RUN echo 'deb https://apt.fullstaqruby.org ubuntu-18.04 main' > /etc/apt/sources
 ENV PATH /usr/lib/fullstaq-ruby/versions/2.7/bin/:$PATH
 
 # Node
-ENV NODE_VERSION 12.22.4
+ENV NODE_VERSION 12.22.5
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
 RUN curl -sLO "https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get install -y ./$DEB_FILE \

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@
 2. Edit this README.md. Document the new image resource versions above.
 3. Make the version changes in the Dockerfile. NOTE: Check http://chromedriver.chromium.org/home to determine the current stable chromedriver version. We only specify the major and minor version for the ruby version. The version that is built into docker images is whatever the most recent patchlevel release is available from the FullStaq ruby repository. The same is true for our production server instances. When new instances are made, they get the latest ruby patchlevel version available.
 4. To create an image, follow this example: `docker build -f Dockerfile.chefdk -t mckessoncds/ci-docker-images:2021.08.04-chefdk .`
-   NOTE: Tag in the form \<date>-<cvp, cds, quill or chefdk>
+   <br />NOTE: Tag in the form \<date>-<cvp, cds, quill or chefdk>
 5. Test the image, checking the versions: `docker run -it mckessoncds/ci-docker-images:<image tag> /bin/bash`
-6. If the image changes are correct, create a pull request and get it merged, and then tag a github release note.
-7. To push the new image(s) to hub.docker.com, run `docker push mckessoncds/ci-docker-images:<image tag>`
-8. Create and merge a PR, and then tag a Github and Jira release
+6. To push the new image(s) to hub.docker.com, run `docker push mckessoncds/ci-docker-images:<image tag>`
+7. Create and merge a PR, and then tag a Github and Jira release
 
 ## Current Docker Images for CircleCI
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 1. git co -b \<JIRA ticket ID>
 2. Edit this README.md. Document the new image resource versions above.
 3. Make the version changes in the Dockerfile. NOTE: Check http://chromedriver.chromium.org/home to determine the current stable chromedriver version. We only specify the major and minor version for the ruby version. The version that is built into docker images is whatever the most recent patchlevel release is available from the FullStaq ruby repository. The same is true for our production server instances. When new instances are made, they get the latest ruby patchlevel version available.
-4. To create an image, follow this example: `docker build -f Dockerfile.chefdk -t mckessoncds/ci-docker-images:2021.08.04-chefdk .`
-   <br />NOTE: Tag in the form \<date>-<cvp, cds, quill or chefdk>
+4. To create an image, follow this example: <br />`docker build -f Dockerfile.chefdk -t mckessoncds/ci-docker-images:2021.08.04-chefdk .` <br />NOTE: Tag in the form \<date>-<cvp, cds, quill or chefdk>
 5. Test the image, checking the versions: `docker run -it mckessoncds/ci-docker-images:<image tag> /bin/bash`
 6. To push the new image(s) to hub.docker.com, run `docker push mckessoncds/ci-docker-images:<image tag>`
 7. Create and merge a PR, and then tag a Github and Jira release

--- a/README.md
+++ b/README.md
@@ -1,51 +1,43 @@
-To Create and Upload New Image(s) 
---------------------
+## To Create and Upload New Image(s)
 
 1. git co -b \<JIRA ticket ID>
 2. Edit this README.md. Document the new image resource versions above.
-3. Make the version changes in the Dockerfile.  NOTE: Check http://chromedriver.chromium.org/home to determine the current stable chromedriver version. We only specify the major and minor version for the ruby version. The version that is built into docker images is whatever the most recent patchlevel release is available from the FullStaq ruby repository. The same is true for our production server instances. When new instances are made, they get the latest ruby patchlevel version available. 
-4. To create an image, follow this example:  `docker build -f Dockerfile.chefdk -t mckessoncds/ci-docker-images:2021.08.04-chefdk .`
-   NOTE:  Tag in the form \<date>-<cvp, cds, quill or chefdk>
-5. Test the image, checking the versions:  `docker run -it mckessoncds/ci-docker-images:<image tag> /bin/bash`
+3. Make the version changes in the Dockerfile. NOTE: Check http://chromedriver.chromium.org/home to determine the current stable chromedriver version. We only specify the major and minor version for the ruby version. The version that is built into docker images is whatever the most recent patchlevel release is available from the FullStaq ruby repository. The same is true for our production server instances. When new instances are made, they get the latest ruby patchlevel version available.
+4. To create an image, follow this example: `docker build -f Dockerfile.chefdk -t mckessoncds/ci-docker-images:2021.08.04-chefdk .`
+   NOTE: Tag in the form \<date>-<cvp, cds, quill or chefdk>
+5. Test the image, checking the versions: `docker run -it mckessoncds/ci-docker-images:<image tag> /bin/bash`
 6. If the image changes are correct, create a pull request and get it merged, and then tag a github release note.
 7. To push the new image(s) to hub.docker.com, run `docker push mckessoncds/ci-docker-images:<image tag>`
 8. Create and merge a PR, and then tag a Github and Jira release
 
-Current Docker Images for CircleCI
-----------------
+## Current Docker Images for CircleCI
 
 These are [public images](https://hub.docker.com/r/mckessoncds/ci-docker-images) to run CI (continuous integration) building and testing for an Ruby/Node application. The intention is create baseline images that CI will use to run and test our application. These images have the required language support (Ruby, Node), and required test tools (ChefDK, phantomjs, codeclimate).
 
 The naming convention is as follows (alphabetically increasing city names):
 
-| Name:tag          | Ruby  | Rubygems | Bundler |  Node   |  Yarn  | chromedriver  |
-|------------------:|------:|---------:|--------:|--------:|-------:|--------------:|
-| 2021.08.04-cds    | 2.7.x | 3.1.6    | 2.2.25  | 12.22.4 | 1.22.5 | 92.0.4515.107 |
-| 2021.08.04-cvp    | 2.7.x | 3.1.6    | 2.2.25  | 14.17.4 | 1.22.5 | 92.0.4515.107 |
-| 2021.08.26-quill  | 2.7.x | 3.1.6    | 2.2.25  | 14.17.5 | 1.22.5 | 92.0.4515.107 |
-| 2021.08.04-chefdk | 2.3.5 | 2.6.14   | 1.16.0  |         |        |               |
+|          Name:tag |  Ruby | Rubygems | Bundler |    Node |   Yarn |  chromedriver |
+| ----------------: | ----: | -------: | ------: | ------: | -----: | ------------: |
+|    2021.08.30-cds | 2.7.x |    3.1.6 |  2.2.25 | 12.22.5 | 1.22.5 | 92.0.4515.107 |
+|    2021.08.04-cvp | 2.7.x |    3.1.6 |  2.2.25 | 14.17.4 | 1.22.5 | 92.0.4515.107 |
+|  2021.08.26-quill | 2.7.x |    3.1.6 |  2.2.25 | 14.17.5 | 1.22.5 | 92.0.4515.107 |
+| 2021.08.04-chefdk | 2.3.5 |   2.6.14 |  1.16.0 |         |        |               |
 
+Note: Going forward, our server instances will use the version of rubygems that is provided by FullStaq ruby.
 
-Note:  Going forward, our server instances will use the version of rubygems that is provided by FullStaq ruby.
-
-
-Docker for Mac
---------------
+## Docker for Mac
 
 https://store.docker.com/editions/community/docker-ce-desktop-mac
 
 - Download, drag to Applications, run it and log in.
 
-Java JDK
---------
+## Java JDK
 
 The JDK download is here:
 
 http://www.oracle.com/technetwork/java/javase/downloads/java-archive-downloads-javase6-419409.html
 
-
-ChefDK
-------
+## ChefDK
 
 OpsWorks requires that we use a very old version of ChefDK (1.6.11).
 


### PR DESCRIPTION
[CDS-6990](https://projects.mckessonspecialtyhealth.com/jira/browse/CDS-6990)

* Minor fixes for process documentation.
* Use node 12.22.5, ruby 2.7.4 to remediate some CVEs in node and ruby.

**Node:**
[CVE-2021-22931](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22931): Improper handling of untypical characters in domain names (High)
[CVE-2021-22930](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22930): Use after free on close http2 on stream canceling (High)

**Ruby:**
https://nvd.nist.gov/vuln/detail/CVE-2021-32066: A StartTLS stripping vulnerability was discovered in Net::IMAP (High)
https://nvd.nist.gov/vuln/detail/CVE-2021-31799: In RDoc 3.11 through 6.x before 6.3.1, as distributed with Ruby through 3.0.1, it is possible to execute arbitrary code via | and tags in a filename. (High)