### PR TITLE
CDS-7069 - New docker images for cvp, cds-tools and quill

### DIFF
--- a/Dockerfile.cds
+++ b/Dockerfile.cds
@@ -41,7 +41,7 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-ENV CHROMEDRIVER_VERSION 92.0.4515.107
+ENV CHROMEDRIVER_VERSION 93.0.4577.63
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
   && unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
 
@@ -68,7 +68,7 @@ RUN echo 'deb https://apt.fullstaqruby.org ubuntu-18.04 main' > /etc/apt/sources
 ENV PATH /usr/lib/fullstaq-ruby/versions/2.7/bin/:$PATH
 
 # Node
-ENV NODE_VERSION 12.22.5
+ENV NODE_VERSION 12.22.6
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
 RUN curl -sLO "https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get install -y ./$DEB_FILE \

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -73,7 +73,7 @@ RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-ser
   && echo 'gem: --no-document' >> ~/.gemrc
 ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
-ENV NODE_VERSION 14.17.5
+ENV NODE_VERSION 14.17.6
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
 RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get update \
@@ -95,7 +95,7 @@ RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 ENV BUNDLER_VERSION 2.2.25
 RUN gem install bundler:$BUNDLER_VERSION
 
-ENV CHROMEDRIVER_VERSION 92.0.4515.107
+ENV CHROMEDRIVER_VERSION 93.0.4577.63
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
   && unzip chromedriver_linux64.zip -d /usr/local/bin \
   && rm chromedriver_linux64.zip

--- a/Dockerfile.quill
+++ b/Dockerfile.quill
@@ -53,7 +53,7 @@ RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-ser
   && echo 'gem: --no-document' >> ~/.gemrc
 ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
-ENV NODE_VERSION 14.17.5
+ENV NODE_VERSION 14.17.6
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
 RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get update \
@@ -75,7 +75,7 @@ RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 ENV BUNDLER_VERSION 2.2.25
 RUN gem install bundler:$BUNDLER_VERSION
 
-ENV CHROMEDRIVER_VERSION 92.0.4515.107
+ENV CHROMEDRIVER_VERSION 93.0.4577.63
 RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
   && unzip chromedriver_linux64.zip -d /usr/local/bin \
   && rm chromedriver_linux64.zip

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The naming convention is as follows (alphabetically increasing city names):
 
 |          Name:tag |  Ruby | Rubygems | Bundler |    Node |   Yarn |  chromedriver |
 | ----------------: | ----: | -------: | ------: | ------: | -----: | ------------: |
-|    2021.08.30-cds | 2.7.x |    3.1.6 |  2.2.25 | 12.22.5 | 1.22.5 | 92.0.4515.107 |
-|    2021.09.01-cvp | 2.7.x |    3.1.6 |  2.2.25 | 14.17.5 | 1.22.5 | 92.0.4515.107 |
-|  2021.08.26-quill | 2.7.x |    3.1.6 |  2.2.25 | 14.17.5 | 1.22.5 | 92.0.4515.107 |
+|    2021.09.13-cds | 2.7.x |    3.1.6 |  2.2.25 | 12.22.6 | 1.22.5 |  93.0.4577.63 |
+|    2021.09.13-cvp | 2.7.x |    3.1.6 |  2.2.25 | 14.17.6 | 1.22.5 |  93.0.4577.63 |
+|  2021.09.13-quill | 2.7.x |    3.1.6 |  2.2.25 | 14.17.6 | 1.22.5 |  93.0.4577.63 |
 | 2021.08.04-chefdk | 2.3.5 |   2.6.14 |  1.16.0 |         |        |               |
 
 Note: Going forward, our server instances will use the version of rubygems that is provided by FullStaq ruby.


### PR DESCRIPTION
Update node for CVEs.

This will remediate some CVEs in node:
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.22.6 

CVE-2021-37701
CVE-2021-37712
CVE-2021-37713
CVE-2021-39134
CVE-2021-39135

Update chromedriver and chrome to latest stable releases.