### PR TITLE
CDS-8287 update dockerfiles to current version

### DIFF
--- a/Dockerfile.cds
+++ b/Dockerfile.cds
@@ -1,5 +1,8 @@
 FROM ubuntu:18.04
-LABEL maintainer="kevin.olbrich@mckesson.com"
+LABEL maintainer="ontada-cds@mckesson.com"
+
+# Update ubuntu to LTS Enablement - Supported until Spring 2028, CDS-8287
+RUN sudo apt-get install --install-recommends linux-generic-hwe-18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -41,9 +44,12 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-ENV CHROMEDRIVER_VERSION 93.0.4577.63
-RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
-  && unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
+# old - not current
+# ENV CHROMEDRIVER_VERSION 93.0.4577.63
+# RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
+#   && unzip chromedriver_linux64.zip -d /usr/local/bin && rm chromedriver_linux64.zip
+
+
 
 # Install the latest stable Chrome
 RUN curl -SO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
@@ -53,13 +59,27 @@ RUN curl -SO https://dl.google.com/linux/direct/google-chrome-stable_current_amd
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
 
+# current chrome install
+RUN BROWSER_MAJOR=$(google-chrome --version | sed 's/Google Chrome \([1-9]..\).*/\1/g') && \
+wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${BROWSER_MAJOR} -O chrome_version && \
+wget https://chromedriver.storage.googleapis.com/`cat chrome_version`/chromedriver_linux64.zip && \
+unzip chromedriver_linux64.zip && \
+mv chromedriver /usr/local/bin/ && \
+DRIVER_MAJOR=$(chromedriver --version | sed 's/ChromeDriver \([0-9]..\).*/\1/g') && \
+echo "chrome version: $BROWSER_MAJOR" && \
+echo "chromedriver version: $DRIVER_MAJOR" && \
+if [ $BROWSER_MAJOR != $DRIVER_MAJOR ]; \
+  then echo "VERSION MISMATCH"; \
+  exit 1; \
+  fi
+
 # PhantomJS
 ENV PHANTOMJS_VERSION 2.1.1
 RUN curl --compressed -L --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-$PHANTOMJS_VERSION \
   && chmod a+x /usr/local/bin/phantomjs
 
 # Ruby
-ENV RUBY_VERSION 2.7
+ENV RUBY_VERSION 2.7.7
 RUN echo 'deb https://apt.fullstaqruby.org ubuntu-18.04 main' > /etc/apt/sources.list.d/fullstaq-ruby.list \
   && curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/main/fullstaq-ruby.asc \
   && apt-key add fullstaq-ruby.asc \
@@ -68,14 +88,14 @@ RUN echo 'deb https://apt.fullstaqruby.org ubuntu-18.04 main' > /etc/apt/sources
 ENV PATH /usr/lib/fullstaq-ruby/versions/2.7/bin/:$PATH
 
 # Node
-ENV NODE_VERSION 12.22.6
+ENV NODE_VERSION 12.22.12
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
 RUN curl -sLO "https://deb.nodesource.com/node_12.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get install -y ./$DEB_FILE \
   && rm $DEB_FILE
 
 # Yarn
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.19
 RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
@@ -87,5 +107,5 @@ RUN chmod a+x /usr/local/bin/cc-test-reporter
 
 # Bundler
 RUN echo 'gem: --no-document' >> ~/.gemrc
-ENV BUNDLER_VERSION 2.2.25
+ENV BUNDLER_VERSION 2.3.26
 RUN gem install bundler:$BUNDLER_VERSION

--- a/Dockerfile.cds
+++ b/Dockerfile.cds
@@ -1,9 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="ontada-cds@mckesson.com"
 
-# Update ubuntu to LTS Enablement - Supported until Spring 2028, CDS-8287
-RUN sudo apt-get install --install-recommends linux-generic-hwe-18.04
-
 ENV DEBIAN_FRONTEND noninteractive
 
 # Add McKesson root certificate to cert chain

--- a/Dockerfile.chefdk
+++ b/Dockerfile.chefdk
@@ -1,9 +1,6 @@
 FROM ubuntu:16.04
 LABEL maintainer="ontada-cds@mckesson.com"
 
-# Update ubuntu to LTS Enablement - Supported until Spring 2028, CDS-8287
-RUN sudo apt-get install --install-recommends linux-generic-hwe-16.04
-
 ENV DEBIAN_FRONTEND noninteractive
 
 # Add McKesson root certificate to cert chain

--- a/Dockerfile.chefdk
+++ b/Dockerfile.chefdk
@@ -1,5 +1,8 @@
 FROM ubuntu:16.04
-LABEL maintainer="kevin.olbrich@mckesson.com"
+LABEL maintainer="ontada-cds@mckesson.com"
+
+# Update ubuntu to LTS Enablement - Supported until Spring 2028, CDS-8287
+RUN sudo apt-get install --install-recommends linux-generic-hwe-16.04
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -1,6 +1,9 @@
 FROM ubuntu:18.04
 LABEL maintainer="ontada-cds@mckesson.com"
 
+# Update ubuntu to LTS Enablement - Supported untilSpring 2028, CDS-8287
+RUN sudo apt-get install --install-recommends linux-generic-hwe-18.04
+
 ENV DEBIAN_FRONTEND noninteractive
 
 # Java

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -78,7 +78,7 @@ ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
 ENV NODE_VERSION 16.19.0
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
-RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
+RUN curl -sLO "https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get update \
   && apt-get install -y ./$DEB_FILE \
   && rm $DEB_FILE \

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 LABEL maintainer="ontada-cds@mckesson.com"
 
-# Update ubuntu to LTS Enablement - Supported untilSpring 2028, CDS-8287
+# Update ubuntu to LTS Enablement - Supported until Spring 2028, CDS-8287
 RUN sudo apt-get install --install-recommends linux-generic-hwe-18.04
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -1,9 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="ontada-cds@mckesson.com"
 
-# Update ubuntu to LTS Enablement - Supported until Spring 2028, CDS-8287
-RUN sudo apt-get install --install-recommends linux-generic-hwe-18.04
-
 ENV DEBIAN_FRONTEND noninteractive
 
 # Java

--- a/Dockerfile.cvp
+++ b/Dockerfile.cvp
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-LABEL maintainer="kevin.olbrich@mckesson.com"
+LABEL maintainer="ontada-cds@mckesson.com"
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -62,7 +62,7 @@ RUN curl --compressed -L --output /usr/local/bin/phantomjs https://s3.amazonaws.
   && chmod a+x /usr/local/bin/phantomjs
 
 # Ruby
-ENV RUBY_VERSION 2.7
+ENV RUBY_VERSION 2.7.7
 RUN echo 'deb https://apt.fullstaqruby.org ubuntu-18.04 main' > /etc/apt/sources.list.d/fullstaq-ruby.list
 RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/main/fullstaq-ruby.asc \
   && apt-key add fullstaq-ruby.asc \
@@ -73,7 +73,7 @@ RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-ser
   && echo 'gem: --no-document' >> ~/.gemrc
 ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
-ENV NODE_VERSION 14.17.6
+ENV NODE_VERSION 16.19.0
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
 RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get update \
@@ -83,7 +83,7 @@ RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FIL
   && apt-get clean
 
 # Yarn
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.19
 RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
@@ -92,13 +92,8 @@ RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && apt-get clean
 
 # Ruby gems & bundler
-ENV BUNDLER_VERSION 2.2.25
+ENV BUNDLER_VERSION 2.3.26
 RUN gem install bundler:$BUNDLER_VERSION
-
-ENV CHROMEDRIVER_VERSION 93.0.4577.63
-RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
-  && unzip chromedriver_linux64.zip -d /usr/local/bin \
-  && rm chromedriver_linux64.zip
 
 # Install the latest stable Chrome
 RUN curl -SO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
@@ -107,6 +102,26 @@ RUN curl -SO https://dl.google.com/linux/direct/google-chrome-stable_current_amd
   && rm google-chrome-stable_current_amd64.deb \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get clean
+
+# previous changes, not removing at this time
+
+# ENV CHROMEDRIVER_VERSION 93.0.4577.63
+# RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
+#   && unzip chromedriver_linux64.zip -d /usr/local/bin \
+#   && rm chromedriver_linux64.zip
+
+# new change pulled from jfrog
+RUN  BROWSER_MAJOR=$(google-chrome --version | sed 's/Google Chrome \([1-9]..\).*/\1/g') && \
+ wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${BROWSER_MAJOR} -O chrome_version && \
+ wget https://chromedriver.storage.googleapis.com/`cat chrome_version`/chromedriver_linux64.zip && \
+ unzip chromedriver_linux64.zip && \
+  mv chromedriver /usr/local/bin/ && DRIVER_MAJOR=$(chromedriver --version | sed 's/ChromeDriver \([0-9]..\).*/\1/g') && \
+  echo "chrome version: $BROWSER_MAJOR" && \
+  echo "chromedriver version: $DRIVER_MAJOR" && \
+  if [ $BROWSER_MAJOR != $DRIVER_MAJOR ]; \
+    then echo "VERSION MISMATCH"; \
+    exit 1; \
+  fi 
 
 # CodeClimate
 RUN curl --compressed -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter

--- a/Dockerfile.quill
+++ b/Dockerfile.quill
@@ -1,9 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="ontada-cds@mckesson.com"
 
-# Update ubuntu to LTS Enablement - Supported until Spring 2028, CDS-8287
-RUN sudo apt-get install --install-recommends linux-generic-hwe-18.04
-
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \

--- a/Dockerfile.quill
+++ b/Dockerfile.quill
@@ -1,5 +1,5 @@
 FROM ubuntu:18.04
-LABEL maintainer="kevin.olbrich@mckesson.com"
+LABEL maintainer="ontada-cds@mckesson.com"
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -42,7 +42,7 @@ RUN curl --compressed -L --output dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.g
   && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 # Ruby
-ENV RUBY_VERSION 2.7
+ENV RUBY_VERSION 2.7.7
 RUN echo 'deb https://apt.fullstaqruby.org ubuntu-18.04 main' > /etc/apt/sources.list.d/fullstaq-ruby.list
 RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-server-edition/main/fullstaq-ruby.asc \
   && apt-key add fullstaq-ruby.asc \
@@ -53,9 +53,9 @@ RUN curl -SLfO https://raw.githubusercontent.com/fullstaq-labs/fullstaq-ruby-ser
   && echo 'gem: --no-document' >> ~/.gemrc
 ENV PATH /usr/lib/fullstaq-ruby/versions/${RUBY_VERSION}/bin/:$PATH
 
-ENV NODE_VERSION 14.17.6
+ENV NODE_VERSION 16.19.0
 ENV DEB_FILE nodejs_$NODE_VERSION-1nodesource1_amd64.deb
-RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FILE}" \
+RUN curl -sLO "https://deb.nodesource.com/node_16.x/pool/main/n/nodejs/${DEB_FILE}" \
   && apt-get update \
   && apt-get install -y ./$DEB_FILE \
   && rm $DEB_FILE \
@@ -63,7 +63,7 @@ RUN curl -sLO "https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/${DEB_FIL
   && apt-get clean
 
 # Yarn
-ENV YARN_VERSION 1.22.5
+ENV YARN_VERSION 1.22.19
 RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
   && apt-get update \
@@ -72,13 +72,28 @@ RUN curl -SL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
   && apt-get clean
 
 # Ruby gems & bundler
-ENV BUNDLER_VERSION 2.2.25
+ENV BUNDLER_VERSION 2.3.26
 RUN gem install bundler:$BUNDLER_VERSION
 
-ENV CHROMEDRIVER_VERSION 93.0.4577.63
-RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
-  && unzip chromedriver_linux64.zip -d /usr/local/bin \
-  && rm chromedriver_linux64.zip
+# old - not current
+# ENV CHROMEDRIVER_VERSION 93.0.4577.63
+# RUN curl -O https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip \
+#   && unzip chromedriver_linux64.zip -d /usr/local/bin \
+#   && rm chromedriver_linux64.zip
+
+# current chrome install from dockerfile
+RUN BROWSER_MAJOR=$(google-chrome --version | sed 's/Google Chrome \([1-9]..\).*/\1/g') && \
+wget https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${BROWSER_MAJOR} -O chrome_version && \
+wget https://chromedriver.storage.googleapis.com/`cat chrome_version`/chromedriver_linux64.zip && \
+unzip chromedriver_linux64.zip && \
+mv chromedriver /usr/local/bin/ && \
+DRIVER_MAJOR=$(chromedriver --version | sed 's/ChromeDriver \([0-9]..\).*/\1/g') && \
+echo "chrome version: $BROWSER_MAJOR" && \
+echo "chromedriver version: $DRIVER_MAJOR" && \
+if [ $BROWSER_MAJOR != $DRIVER_MAJOR ]; \
+  then echo "VERSION MISMATCH"; \
+  exit 1; \
+fi 
 
 # Install the latest stable Chrome
 RUN curl -SO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \

--- a/Dockerfile.quill
+++ b/Dockerfile.quill
@@ -1,6 +1,9 @@
 FROM ubuntu:18.04
 LABEL maintainer="ontada-cds@mckesson.com"
 
+# Update ubuntu to LTS Enablement - Supported until Spring 2028, CDS-8287
+RUN sudo apt-get install --install-recommends linux-generic-hwe-18.04
+
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 
 ## NOTICE 
 
-*CDS Images are stored in JFROG*
+*CDS Images are stored in JFROG, you must be a member of the ontada-cds group to access them*
 
 These will be moved into their respective applications when we move into Enterprise Github. CI/CD will be moved into Github Actions and this repo will be archived.
+
+
+Dockerfile.chefdk does not appear to be in use.
 
 ***
 # OLD INSTRUCTIONS - NOT CURRENT

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+
+## NOTICE 
+
+*CDS Images are stored in JFROG*
+
+These will be moved into their respective applications when we move into Enterprise Github. CI/CD will be moved into Github Actions and this repo will be archived.
+
+***
+# OLD INSTRUCTIONS - NOT CURRENT
 ## To Create and Upload New Image(s)
 
 1. git co -b \<JIRA ticket ID>


### PR DESCRIPTION
These dockerfiles have not been updated in some time, and were out of date with current versions in mck-cds.jfrog.io. This pr updates them to the current versions, and updates the maintainer email to current McK employees. Updated readme also.